### PR TITLE
A8-work

### DIFF
--- a/assignments/A7_3_Address_Code/test75.tac
+++ b/assignments/A7_3_Address_Code/test75.tac
@@ -1,6 +1,6 @@
 proc five
 proc fun
-_t1 = _BP+4 MUL _BP+6
+_t1 = _BP+4 MUL _BP+2
 c = _t1
 endp fun
 _t2 = 5

--- a/src/jakadac/modules/rd_parser_mixins_declarations.py
+++ b/src/jakadac/modules/rd_parser_mixins_declarations.py
@@ -340,7 +340,9 @@ class DeclarationsMixin:
                         # Assign offset and update next offset
                         param_symbol.set_variable_info(param_type, current_param_offset, param_size)
                         self.logger.debug(f" Assigning offset {current_param_offset} to param '{param_name}'")
-                        current_param_offset += param_size 
+                        # FIXED: Decrement parameter offset instead of incrementing
+                        # Parameters should be assigned decreasing offsets (4, 2) rather than (4, 6)
+                        current_param_offset -= param_size
                         
                         proc_symbol_params.append(param_symbol) # Store symbol for later?
                         proc_symbol_modes[param_name] = param_mode


### PR DESCRIPTION
Introduces logic to identify and buffer instructions belonging to the main (outermost) procedure.

Defers the emission of the main procedure's instructions until all other procedures have been processed.

Appends the buffered main procedure definition to the end of the Three-Address Code list before writing the output file, ensuring it appears after all nested procedures.